### PR TITLE
Fix dunamis not saving

### DIFF
--- a/src/main/java/cookie/thaumaturgy/Thaumaturgy.java
+++ b/src/main/java/cookie/thaumaturgy/Thaumaturgy.java
@@ -1,7 +1,6 @@
 package cookie.thaumaturgy;
 
 import cookie.thaumaturgy.api.Dunami;
-import cookie.thaumaturgy.api.Dunamis;
 import cookie.thaumaturgy.block.ThaumBlocks;
 import cookie.thaumaturgy.item.ThaumItems;
 import net.fabricmc.api.ModInitializer;
@@ -9,9 +8,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import turniplabs.halplibe.util.ClientStartEntrypoint;
 import turniplabs.halplibe.util.GameStartEntrypoint;
-
-import java.util.ArrayList;
-import java.util.List;
 
 
 public class Thaumaturgy implements ModInitializer, GameStartEntrypoint, ClientStartEntrypoint {

--- a/src/main/java/cookie/thaumaturgy/api/Dunamis.java
+++ b/src/main/java/cookie/thaumaturgy/api/Dunamis.java
@@ -36,4 +36,9 @@ public class Dunamis {
 	public List<Dunamis> getComposition() {
 		return composition;
 	}
+
+	@Override
+	public String toString() {
+		return getName();
+	}
 }

--- a/src/main/java/cookie/thaumaturgy/api/DunamisBuilder.java
+++ b/src/main/java/cookie/thaumaturgy/api/DunamisBuilder.java
@@ -1,10 +1,8 @@
 package cookie.thaumaturgy.api;
 
-import cookie.thaumaturgy.Thaumaturgy;
-
 import java.util.List;
 
-public final class DunamisBuilder {
+public class DunamisBuilder {
 	private final String name;
 	private int color;
 	private int texture;

--- a/src/main/java/cookie/thaumaturgy/api/DunamisStack.java
+++ b/src/main/java/cookie/thaumaturgy/api/DunamisStack.java
@@ -13,7 +13,7 @@ public class DunamisStack {
 		this(dunamis, 1);
 	}
 
-	public Dunamis getAspect() {
+	public Dunamis getDunamis() {
 		return dunamis;
 	}
 }

--- a/src/main/java/cookie/thaumaturgy/api/IDunamisContainer.java
+++ b/src/main/java/cookie/thaumaturgy/api/IDunamisContainer.java
@@ -1,12 +1,10 @@
-package cookie.thaumaturgy.interfaces;
+package cookie.thaumaturgy.api;
 
 import com.mojang.nbt.CompoundTag;
-import cookie.thaumaturgy.api.Dunamis;
-import cookie.thaumaturgy.api.DunamisStack;
 
 public interface IDunamisContainer {
 	default int addDunamis(DunamisStack stack, boolean simulate) {
-		return addDunamis(stack.getAspect(), stack.amount, simulate);
+		return addDunamis(stack.getDunamis(), stack.amount, simulate);
 	}
 
 	int addDunamis(Dunamis dunamis, int amount, boolean simulate);
@@ -14,7 +12,7 @@ public interface IDunamisContainer {
 	int takeDunamis(Dunamis dunamis, int amount, boolean simulate);
 
 	default boolean takeDunamis(DunamisStack stack, boolean simulate) {
-		return setDunamis(stack.getAspect(), stack.amount, simulate);
+		return setDunamis(stack.getDunamis(), stack.amount, simulate);
 	}
 
 	boolean setDunamis(Dunamis dunamis, int amount, boolean simulate);
@@ -24,6 +22,8 @@ public interface IDunamisContainer {
 	boolean hasDunamis(Dunamis dunamis);
 
 	DunamisStack[] getDunami();
+
+	boolean isEmpty();
 
 	default int getCapacity() {
 		return 8192;

--- a/src/main/java/cookie/thaumaturgy/api/ItemDunamisContainer.java
+++ b/src/main/java/cookie/thaumaturgy/api/ItemDunamisContainer.java
@@ -1,27 +1,30 @@
-package cookie.thaumaturgy.block.entity;
+package cookie.thaumaturgy.api;
 
 import com.mojang.nbt.CompoundTag;
-import cookie.thaumaturgy.api.Dunami;
-import cookie.thaumaturgy.api.Dunamis;
-import cookie.thaumaturgy.api.DunamisStack;
-import cookie.thaumaturgy.api.IDunamisContainer;
-import net.minecraft.core.block.entity.TileEntity;
+import net.minecraft.core.item.ItemStack;
 
 import java.util.HashMap;
 import java.util.Map;
 
-public class TileEntityNode extends TileEntity implements IDunamisContainer {
-	private int regenRate;
-	private int particleRate;
+public class ItemDunamisContainer implements IDunamisContainer {
 	private final Map<Dunamis, Integer> dunami = new HashMap<>();
-	public static final String[] particles = new String[]{
-		"bubble",
-		"splash",
-		"explode",
-		"flame",
-		"bigsmoke",
-		"portal"
-	};
+	private final ItemStack item;
+
+	public ItemDunamisContainer(ItemStack stack) {
+		this.item = stack;
+		readFromNBT(stack.getData());
+	}
+
+	public ItemStack save() {
+		CompoundTag tag = this.item.getData();
+		writeToNBT(tag);
+		this.item.setData(tag);
+		return this.item;
+	}
+
+	public ItemStack getItemStack() {
+		return save();
+	}
 
 	@Override
 	public int addDunamis(Dunamis dunamis, int amount, boolean simulate) {
@@ -87,65 +90,22 @@ public class TileEntityNode extends TileEntity implements IDunamisContainer {
 		return stacks;
 	}
 
-	public TileEntityNode() {
-
-	}
-
-	@Override
-	public void tick() {
-		if (worldObj != null && !worldObj.isClientSide) {
-			// Regenerate the available mana if it's below 32 and above 0.
-			if (regenRate++ >= 200) {
-				regenRate = 0;
-				for (Dunamis dunamis : dunami.keySet()) {
-					int amount = dunami.get(dunamis);
-					if (amount > 0 && amount < 32) addDunamis(new DunamisStack(dunamis, 1), false);
-				}
-			}
-
-			if (dunami.isEmpty()) {
-				for (Dunamis dunamis : Dunami.DUNAMI) {
-					if (worldObj.rand.nextInt(5) == 0) {
-						setDunamis(dunamis, worldObj.rand.nextInt(4) + 1, false);
-					}
-				}
-			}
-
-			// TODO - find or create more particles!
-			// This spawns 5 of the corresponding particles for each mana type.
-			if (particleRate++ >= 100) {
-				particleRate = 0;
-				for (int i = 0; i < 5; i++) {
-					double randX = x + worldObj.rand.nextDouble();
-					double randY = y + worldObj.rand.nextDouble();
-					double randZ = z + worldObj.rand.nextDouble();
-					for (int a = 0; a < Dunami.DUNAMI.size(); a++) {
-						if (hasDunamis(Dunami.DUNAMI.get(a))) {
-							worldObj.spawnParticle(a < particles.length ? particles[a] : "flame", randX, randY, randZ, 0, 0, 0);
-						}
-					}
-				}
-			}
-		}
-	}
-
 	@Override
 	public void writeToNBT(CompoundTag tag) {
-		super.writeToNBT(tag);
 		CompoundTag dunami = new CompoundTag();
 		for (Dunamis dunamis : this.dunami.keySet()) {
-			dunami.putInt(dunamis.getName(), getDunamis(dunamis));
+			dunami.putInt(dunamis.getName(), this.dunami.get(dunamis));
 		}
 		tag.put("dunami", dunami);
 	}
 
 	@Override
 	public void readFromNBT(CompoundTag tag) {
-		super.readFromNBT(tag);
-		this.dunami.clear();
-		CompoundTag aspects = tag.getCompound("dunami");
+		CompoundTag dunami = tag.getCompound("dunami");
 		for (Dunamis dunamis : Dunami.DUNAMI) {
-			setDunamis(dunamis, aspects.getInteger(dunamis.getName()), false);
+			if (dunami.containsKey(dunamis.getName())) {
+				setDunamis(dunamis, dunami.getInteger(dunamis.getName()), false);
+			}
 		}
 	}
 }

--- a/src/main/java/cookie/thaumaturgy/api/ThaumaturgyAPI.java
+++ b/src/main/java/cookie/thaumaturgy/api/ThaumaturgyAPI.java
@@ -3,7 +3,24 @@ package cookie.thaumaturgy.api;
 import com.mojang.nbt.CompoundTag;
 import net.minecraft.core.item.ItemStack;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public class ThaumaturgyAPI {
+	public static final Map<Dunamis, String> PARTICLE_MAP = new HashMap<>();
+
+	static {
+		PARTICLE_MAP.put(Dunami.AIR, "bubble");
+		PARTICLE_MAP.put(Dunami.WATER, "splash");
+		PARTICLE_MAP.put(Dunami.FIRE, "flame");
+		PARTICLE_MAP.put(Dunami.EARTH, "explode");
+		PARTICLE_MAP.put(Dunami.ORDER, "bigsmoke");
+		PARTICLE_MAP.put(Dunami.CHAOS, "portal");
+	}
+
+	public static String getParticleForDunamis(Dunamis dunamis) {
+		return PARTICLE_MAP.get(dunamis) != null ? PARTICLE_MAP.get(dunamis) : "portal";
+	}
 
 	public static ItemDunamisContainer getItemDunamisContainer(ItemStack stack) {
 		if (!itemStackContainsDunamis(stack)) throw new NullPointerException("Attempt to get dunamis container for item that doesn't have one!");

--- a/src/main/java/cookie/thaumaturgy/api/ThaumaturgyAPI.java
+++ b/src/main/java/cookie/thaumaturgy/api/ThaumaturgyAPI.java
@@ -1,0 +1,25 @@
+package cookie.thaumaturgy.api;
+
+import com.mojang.nbt.CompoundTag;
+import net.minecraft.core.item.ItemStack;
+
+public class ThaumaturgyAPI {
+
+	public static ItemDunamisContainer getItemDunamisContainer(ItemStack stack) {
+		if (!itemStackContainsDunamis(stack)) throw new NullPointerException("Attempt to get dunamis container for item that doesn't have one!");
+		return new ItemDunamisContainer(stack);
+	}
+
+	public static boolean itemStackContainsDunamis(ItemStack stack, boolean checkAmount) {
+		CompoundTag tag = stack.getData();
+		if (tag.containsKey("dunami")) {
+			if (checkAmount) return !getItemDunamisContainer(stack).isEmpty();
+			return true;
+		}
+		return false;
+	}
+
+	public static boolean itemStackContainsDunamis(ItemStack stack) {
+		return itemStackContainsDunamis(stack, false);
+	}
+}

--- a/src/main/java/cookie/thaumaturgy/block/entity/TileEntityNode.java
+++ b/src/main/java/cookie/thaumaturgy/block/entity/TileEntityNode.java
@@ -1,10 +1,7 @@
 package cookie.thaumaturgy.block.entity;
 
 import com.mojang.nbt.CompoundTag;
-import cookie.thaumaturgy.api.Dunami;
-import cookie.thaumaturgy.api.Dunamis;
-import cookie.thaumaturgy.api.DunamisStack;
-import cookie.thaumaturgy.api.IDunamisContainer;
+import cookie.thaumaturgy.api.*;
 import net.minecraft.core.block.entity.TileEntity;
 
 import java.util.HashMap;
@@ -14,14 +11,6 @@ public class TileEntityNode extends TileEntity implements IDunamisContainer {
 	private int regenRate;
 	private int particleRate;
 	private final Map<Dunamis, Integer> dunami = new HashMap<>();
-	public static final String[] particles = new String[]{
-		"bubble",
-		"splash",
-		"explode",
-		"flame",
-		"bigsmoke",
-		"portal"
-	};
 
 	@Override
 	public int addDunamis(Dunamis dunamis, int amount, boolean simulate) {
@@ -116,12 +105,12 @@ public class TileEntityNode extends TileEntity implements IDunamisContainer {
 			if (particleRate++ >= 100) {
 				particleRate = 0;
 				for (int i = 0; i < 5; i++) {
-					double randX = x + worldObj.rand.nextDouble();
-					double randY = y + worldObj.rand.nextDouble();
-					double randZ = z + worldObj.rand.nextDouble();
-					for (int a = 0; a < Dunami.DUNAMI.size(); a++) {
-						if (hasDunamis(Dunami.DUNAMI.get(a))) {
-							worldObj.spawnParticle(a < particles.length ? particles[a] : "flame", randX, randY, randZ, 0, 0, 0);
+					for (Dunamis dunamis : this.dunami.keySet()) {
+						if (hasDunamis(dunamis)) {
+							double randX = x + worldObj.rand.nextDouble();
+							double randY = y + worldObj.rand.nextDouble();
+							double randZ = z + worldObj.rand.nextDouble();
+							worldObj.spawnParticle(ThaumaturgyAPI.getParticleForDunamis(dunamis), randX, randY, randZ, 0, 0, 0);
 						}
 					}
 				}

--- a/src/main/java/cookie/thaumaturgy/item/ItemThaumicReader.java
+++ b/src/main/java/cookie/thaumaturgy/item/ItemThaumicReader.java
@@ -23,7 +23,7 @@ public class ItemThaumicReader extends Item {
 
 			if (tileEntityNode != null && player != null) {
 				for (DunamisStack stack : tileEntityNode.getDunami()) {
-					player.addChatMessage("Node " + stack.getAspect().getName() + ": " + stack.amount);
+					player.addChatMessage("Node " + stack.getDunamis().getName() + ": " + stack.amount);
 				}
 			}
 

--- a/src/main/java/cookie/thaumaturgy/item/ItemWand.java
+++ b/src/main/java/cookie/thaumaturgy/item/ItemWand.java
@@ -63,7 +63,7 @@ public class ItemWand extends Item implements ICustomDescription {
 			for (int i = 0; i < Dunami.DUNAMI.size(); i++) {
 				Dunamis dunamis = Dunami.DUNAMI.get(i);
 				if (tileEntityNode.hasDunamis(dunamis)) {
-					String particle = i < TileEntityNode.particles.length ? TileEntityNode.particles[i] : "flame";
+					String particle = ThaumaturgyAPI.getParticleForDunamis(dunamis);
 					world.spawnParticle(particle, blockX, blockY, blockZ, 0, 0, 0);
 					int taken = tileEntityNode.takeDunamis(dunamis, 2, true);
 					if (taken > 0) {

--- a/src/main/java/cookie/thaumaturgy/item/ItemWand.java
+++ b/src/main/java/cookie/thaumaturgy/item/ItemWand.java
@@ -1,11 +1,8 @@
 package cookie.thaumaturgy.item;
 
 import com.mojang.nbt.CompoundTag;
-import cookie.thaumaturgy.api.Dunami;
-import cookie.thaumaturgy.api.Dunamis;
-import cookie.thaumaturgy.api.DunamisStack;
+import cookie.thaumaturgy.api.*;
 import cookie.thaumaturgy.block.entity.TileEntityNode;
-import cookie.thaumaturgy.interfaces.IDunamisContainer;
 import net.minecraft.core.block.Block;
 import net.minecraft.core.entity.EntityItem;
 import net.minecraft.core.entity.player.EntityPlayer;
@@ -16,11 +13,7 @@ import net.minecraft.core.util.helper.Side;
 import net.minecraft.core.world.World;
 import sunsetsatellite.catalyst.core.util.ICustomDescription;
 
-import java.util.HashMap;
-import java.util.Map;
-
-public class ItemWand extends Item implements ICustomDescription, IDunamisContainer {
-	private final Map<Dunamis, Integer> aspects = new HashMap<>();
+public class ItemWand extends Item implements ICustomDescription {
 
 	public ItemWand(String name, int id) {
 		super(name, id);
@@ -29,83 +22,9 @@ public class ItemWand extends Item implements ICustomDescription, IDunamisContai
 	}
 
 	@Override
-	public int addDunamis(Dunamis dunamis, int amount, boolean simulate) {
-		if (!isDunamisValid(dunamis)) return 0;
-		int current = getDunamis(dunamis);
-		if (current < getCapacity()) {
-			int result = Math.min(current + amount, getCapacity());
-			int diff = result - (current + amount);
-			int added = amount - diff;
-			if (!simulate) aspects.put(dunamis, result);
-			return added;
-		}
-		return 0;
-	}
-
-	@Override
-	public int takeDunamis(Dunamis dunamis, int amount, boolean simulate) {
-		if (!hasDunamis(dunamis)) return 0;
-		int current = getDunamis(dunamis);
-		if (current > 0) {
-			int result = Math.max(current - amount, 0);
-			int diff = result - (current - amount);
-			int removed = amount - diff;
-			if (!simulate) aspects.put(dunamis, result);
-			return removed;
-		}
-		return 0;
-	}
-
-	@Override
-	public boolean setDunamis(Dunamis dunamis, int amount, boolean simulate) {
-		if (!isDunamisValid(dunamis)) return false;
-		aspects.put(dunamis, Math.min(amount, getCapacity()));
-		return true;
-	}
-
-	@Override
-	public int getDunamis(Dunamis dunamis) {
-		return aspects.get(dunamis) != null ? aspects.get(dunamis) : 0;
-	}
-
-	@Override
-	public boolean hasDunamis(Dunamis dunamis) {
-		return getDunamis(dunamis) > 0;
-	}
-
-	@Override
-	public DunamisStack[] getDunami() {
-		DunamisStack[] stacks = new DunamisStack[aspects.size()];
-		int i = 0;
-		for (Dunamis dunamis : aspects.keySet()) {
-			stacks[i++] = new DunamisStack(dunamis, aspects.get(dunamis));
-		}
-		return stacks;
-	}
-
-	@Override
-	public void writeToNBT(CompoundTag tag) {
-		CompoundTag aspects = new CompoundTag();
-		for (Dunamis dunamis : this.aspects.keySet()) {
-			aspects.putInt(dunamis.getName(), this.aspects.get(dunamis));
-		}
-		tag.put("aspects", aspects);
-	}
-
-	@Override
-	public void readFromNBT(CompoundTag tag) {
-		CompoundTag aspects = tag.getCompound("aspects");
-		for (Dunamis dunamis : Dunami.DUNAMI) {
-			if (aspects.containsKey(dunamis.getName())) {
-				setDunamis(dunamis, aspects.getInteger(dunamis.getName()), false);
-			}
-		}
-	}
-
-	@Override
 	public CompoundTag getDefaultTag() {
 		CompoundTag tag = new CompoundTag();
-		tag.put("aspects", new CompoundTag());
+		tag.put("dunami", new CompoundTag());
 		return tag;
 	}
 
@@ -140,23 +59,23 @@ public class ItemWand extends Item implements ICustomDescription, IDunamisContai
 		// Check if the node and player aren't null. If it passes, lower the node count and raise the player's mana.
 		TileEntityNode tileEntityNode = (TileEntityNode) world.getBlockTileEntity(blockX, blockY, blockZ);
 		if (tileEntityNode != null && player != null) {
+			ItemDunamisContainer container = ThaumaturgyAPI.getItemDunamisContainer(itemstack);
 			for (int i = 0; i < Dunami.DUNAMI.size(); i++) {
 				Dunamis dunamis = Dunami.DUNAMI.get(i);
 				if (tileEntityNode.hasDunamis(dunamis)) {
 					String particle = i < TileEntityNode.particles.length ? TileEntityNode.particles[i] : "flame";
 					world.spawnParticle(particle, blockX, blockY, blockZ, 0, 0, 0);
-					int taken = tileEntityNode.takeDunamis(dunamis, 2, false);
+					int taken = tileEntityNode.takeDunamis(dunamis, 2, true);
 					if (taken > 0) {
-						int added = addDunamis(dunamis, taken, false);
-						if (added != taken) {
-							tileEntityNode.addDunamis(dunamis, taken - added, false);
+						int added = container.addDunamis(dunamis, taken, true);
+						if (added == taken) {
+							tileEntityNode.takeDunamis(dunamis, 2, false);
+							container.addDunamis(dunamis, taken, false);
 						}
 					}
 				}
 			}
-			CompoundTag data = itemstack.getData();
-			writeToNBT(data);
-			itemstack.setData(data);
+			container.save();
 			return true;
 		}
 		return false;
@@ -165,10 +84,9 @@ public class ItemWand extends Item implements ICustomDescription, IDunamisContai
 	@Override
 	public ItemStack onItemRightClick(ItemStack itemstack, World world, EntityPlayer player) {
 		if (player != null) {
-			CompoundTag aspects = itemstack.getData().getCompound("aspects");
-			for (Dunamis dunamis : Dunami.DUNAMI) {
-				int amount = aspects.getInteger(dunamis.getName());
-				player.addChatMessage("Aspect " + dunamis.getName() + ", Amount " + amount);
+			IDunamisContainer container = ThaumaturgyAPI.getItemDunamisContainer(itemstack);
+			for (DunamisStack stack : container.getDunami()) {
+				player.addChatMessage("Type: " + stack.getDunamis().getName() + " Amount: " + stack.amount);
 			}
 		}
 		return itemstack;


### PR DESCRIPTION
- Wands now handle dunamis storage properly
- Nodes also now save properly
- Getting the particle for a dunamis type is now handled better
- `Dunamis.toString()` now returns the dunamis name